### PR TITLE
Improvements for Lecture 1 slides

### DIFF
--- a/Slides/Introduction/main.tex
+++ b/Slides/Introduction/main.tex
@@ -194,10 +194,10 @@ We can call this equation (same as any other ODE) a \emph{dynamical system}, and
 The normal form of an \emph{n-th order} ordinary differential equation is:
 
 \begin{equation}
-    x^{(n)} = f (x^{(n-1)}, x^{(n-2)}, ..., \ddot{x}, \dot{x}, x, t)
+	x^{(n)} = f (x^{(n-1)}, x^{(n-2)}, ...\,, \ddot{x}, \dot{x}, x, t)
 \end{equation}
-
-where $x = x(t)$ is the solution of the equation. Same as before, it is a \emph{dynamical system}, but this time the set $\{ x, \ \dot{x}, ... , x^{(n-1)} \}$ is called the \emph{state} of the dynamical system.
+			
+where $x = x(t)$ is the solution of the equation. Same as before, it is a \emph{dynamical system}, but this time the set $\{ x, \ \dot{x} , ...\,,x^{(n-1)} \}$ is called the \emph{state} of the dynamical system.
 
 \begin{example}
 \begin{equation}

--- a/Slides/Introduction/main.tex
+++ b/Slides/Introduction/main.tex
@@ -197,7 +197,7 @@ The normal form of an \emph{n-th order} ordinary differential equation is:
     x^{(n)} = f (x^{(n-1)}, x^{(n-2)}, ..., \ddot{x}, \dot{x}, x, t)
 \end{equation}
 
-where $x = x(t)$ is the solution of the equation. Same as before, it is a \emph{dynamical system}, but this time the set $\{ x, \ \dot{x} \ ..., \ x^{(n-1)} \}$ is called the \emph{state} of the dynamical system.
+where $x = x(t)$ is the solution of the equation. Same as before, it is a \emph{dynamical system}, but this time the set $\{ x, \ \dot{x}, ... , x^{(n-1)} \}$ is called the \emph{state} of the dynamical system.
 
 \begin{example}
 \begin{equation}

--- a/Slides/Introduction/main.tex
+++ b/Slides/Introduction/main.tex
@@ -430,7 +430,7 @@ that there exists a linear transformation of the initial conditions of \eqref{eq
 
 We start by recognizing that differentiation is a linear operation, so $\dot{y}(t)$ is a linear transformation of \eqref{eq:ODE} of the solution $y(t)$. 
 
-Next, we know that $y = \bo{w}^\top \bo{x}$ for some $\bo{w} = \myvecT{w_1}{w_2}$:
+Next, we know that $y = \bo{w}^\top \bo{x}$ for some $\bo{w} = \myvec{w_1}{w_2}$:
 
 \begin{equation}
 \dot y = \bo{w}^\top \bo{A} \bo{x}


### PR DESCRIPTION
There is a bug in the state-space representation to ODE example (slide 17): if we transpose w, it must be a column-vector [2x1], otherwise the multiplication will not be possible [2x1 * 2x1] in (18) and [2x1 * 2x2] in (19) and (20).
Other improvements are minor typo fixes.